### PR TITLE
Remove +1 and use utf8 for the string count

### DIFF
--- a/Sources/Libsql/Libsql.swift
+++ b/Sources/Libsql/Libsql.swift
@@ -212,7 +212,7 @@ public class Statement {
                 )
                 try errIf(bind.err)
             case .text(let text):
-                let len = text.count
+                let len = text.utf8.count
                 try text.withCString { text in
                     let bind = libsql_statement_bind_named(
                         self.inner,
@@ -260,7 +260,8 @@ public class Statement {
                 )
                 try errIf(bind.err)
             case .text(let text):
-                let len = text.count
+              
+                let len = text.utf8.count
                 try text.withCString { text in
                     let bind = libsql_statement_bind_value(
                         self.inner,

--- a/Sources/Libsql/Libsql.swift
+++ b/Sources/Libsql/Libsql.swift
@@ -212,7 +212,7 @@ public class Statement {
                 )
                 try errIf(bind.err)
             case .text(let text):
-                let len = text.count + 1
+                let len = text.count
                 try text.withCString { text in
                     let bind = libsql_statement_bind_named(
                         self.inner,
@@ -260,7 +260,7 @@ public class Statement {
                 )
                 try errIf(bind.err)
             case .text(let text):
-                let len = text.count + 1
+                let len = text.count
                 try text.withCString { text in
                     let bind = libsql_statement_bind_value(
                         self.inner,


### PR DESCRIPTION
`withCString` adds a null-terminating byte, the +1 includes that byte as part of the string that is stored in the database.

```swift
case .text(let text):
                let len = text.count + 1
                try text.withCString { text in
                    let bind = libsql_statement_bind_value(
                        self.inner,
                        libsql_text(text, len)
                    )
                    try errIf(bind.err)
                }
```
 It's ignored with a normal string length or select on a row, but you can see it if you `select hex(column)` or try an equality check on a TEXT value.
 
 ```swift
let id = UUID.uuidString
try conn.execute("insert into whatever (id) values(?), id)
try conn.query("select * from whatever where id = ?", id) // returns no rows because the text in the db has 1 extra char on the end
```

but this doesn't work with utf-8 strings, so inserting padmé causes an incomplete utf-8 byte sequence error. so I changed it to use text.utf8.count instead of text.count to get the byte count instead of the char count.
